### PR TITLE
More tests for external API calls and better logging

### DIFF
--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+import logging
+from tests.test_base import BaseTestCase
+from flask import current_app
+from typeseam.setup_logging import DEFAULT_LOGGING_FORMAT
+
+def restore_logging_format(logger):
+    logger.handlers[0].setFormatter(logging.Formatter(DEFAULT_LOGGING_FORMAT))
+
+class TestException(Exception):
+    pass
+
+class TestLogging(BaseTestCase):
+
+    def setUp(self):
+        BaseTestCase.setUp(self)
+
+    def test_logs_errors_correctly(self):
+        with self.assertRaises(TestException):
+            with self.assertLogs( current_app.logger, level='ERROR' ) as context_manager:
+                raise TestException("Hello errors")
+            self.assertIn("Hello errors", context_manager.output)
+            self.assertIn("ERROR", context_manager.output)
+
+    def test_logs_events_correctly(self):
+        logger = current_app.logger
+        self.assertEqual(logger.handlers[0].formatter._fmt, DEFAULT_LOGGING_FORMAT)
+        with self.assertLogs( logger, level='DEBUG' ) as context_manager:
+            logger.info("Something noteable happened")
+            logger.debug("Something happened that isn't very significant")
+        self.assertIn("Something noteable happened", context_manager.output[0])
+        self.assertIn("INFO", context_manager.output[0])
+        self.assertIn("Something happened that isn't very significant", context_manager.output[1])
+        self.assertIn("DEBUG", context_manager.output[1])

--- a/tests/integration/test_logging.py
+++ b/tests/integration/test_logging.py
@@ -24,6 +24,7 @@ class TestLogging(BaseTestCase):
 
     def test_logs_events_correctly(self):
         logger = current_app.logger
+        # make sure we are using the right logging format
         self.assertEqual(logger.handlers[0].formatter._fmt, DEFAULT_LOGGING_FORMAT)
         with self.assertLogs( logger, level='DEBUG' ) as context_manager:
             logger.info("Something noteable happened")

--- a/tests/mock/mock_api_responses.py
+++ b/tests/mock/mock_api_responses.py
@@ -1,19 +1,78 @@
+from unittest import mock
+from tests.mock.factories import (
+    fake_typeform_responses,
+    seamless_form_id,
+    seamless_application_id
+    )
+from requests import Response
 
-from tests.mock.factories import faker, fake_typeform_responses
-from unittest.mock import MagicMock
+
+def generate_fake_requests_response(status_code=200, json=None, **kwargs):
+    props = {
+        'status_code': status_code,
+        'json.return_value': json
+        }
+    props.update(kwargs)
+    response = mock.Mock(**props)
+    response.raise_for_status = lambda: Response.raise_for_status(response)
+    return response
 
 
-good_response = MagicMock()
-sample_response = fake_typeform_responses(2)
-sample_response.update(http_status=200)
-good_response.json.return_value = sample_response
+class FakeResponsesBase:
+    """Each of these class attributes contain a Mock object
+    that imitates a requests.Response object
+    """
+    OK = generate_fake_requests_response(200)
+    ERROR = generate_fake_requests_response(500)
+    NOT_FOUND = generate_fake_requests_response(404)
+    FORBIDDEN = generate_fake_requests_response(403)
 
-forbidden_response = MagicMock()
-forbidden_response.json.return_value = {
-    'http_status': 403,
-}
 
-bad_response = MagicMock()
-bad_response.json.return_value = {
-    'http_status': 500,
-}
+class FakeTypeformAPIResponses(FakeResponsesBase):
+
+    OK = generate_fake_requests_response(
+        json=dict(http_status=200, **fake_typeform_responses(2))
+        )
+
+class FakeSeamlessDocsAPISubmitResponses(FakeResponsesBase):
+
+    OK = generate_fake_requests_response(
+        json={
+            'result': True,
+            'description': 'Submission successful',
+            'application_id': seamless_application_id()
+            }
+        )
+
+    MISSING_DOC = generate_fake_requests_response(
+        status_code=200, json={
+            "error": True,
+            "error_log": [
+                {
+                    "error_code": "form_init_error",
+                    "error_message": "Form '{}' not found".format(seamless_form_id())
+                }
+            ]
+        }
+        )
+
+    VALIDATION_ERROR = generate_fake_requests_response(
+        status_code=200, json={
+        "result": False,
+        "error_log": [
+            {
+                "error_code": "validation_fail",
+                "error_message": "Validation failed on element 'Email Input' ['email_input']: Null value is given for a required field",
+                "error_description": "submission:validate_submission"
+            }
+        ]})
+
+class FakeSeamlessDocsAPIApplicationResponses(FakeResponsesBase):
+
+    OK = generate_fake_requests_response(200,
+        json=['https://somewhere.com/somepdf.pdf'])
+
+    MISSING_PDF = generate_fake_requests_response(200,
+        json=[])
+
+

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -1,32 +1,124 @@
 from unittest.mock import MagicMock, patch
+from requests.exceptions import HTTPError
+from werkzeug.exceptions import NotFound
 
 from flask import current_app
 from typeseam.app import load_initial_data
 
 from typeseam.form_filler.tasks import (
     get_typeform_responses,
-    get_seamless_doc_pdf
+    get_seamless_doc_pdf,
+    submit_answers_to_seamless_docs,
+    retrieve_seamless_docs_pdf_url,
+    SeamlessDocsSubmissionError
     )
 
 
 from tests.test_base import BaseTestCase
 from tests.mock.mock_api_responses import (
-    good_response,
-    forbidden_response,
-    bad_response
+    FakeTypeformAPIResponses,
+    FakeSeamlessDocsAPISubmitResponses,
+    FakeSeamlessDocsAPIApplicationResponses
     )
-
+from tests.mock.factories import (
+    seamless_form_id,
+    fake_translated_typeform_responses
+    )
 
 class TestExternalApiCalls(BaseTestCase):
 
     def setUp(self):
         BaseTestCase.setUp(self)
         load_initial_data(current_app)
+        self.answers = fake_translated_typeform_responses(1).answers
+        self.doc_id = 'CO14950000011885231'
+        self.app_id = 'AP14782000010904892'
 
     @patch('typeseam.form_filler.tasks.requests')
     def test_typeform_success(self, mock_requests):
-        from typeseam.form_filler.tasks import get_typeform_responses
-        mock_requests.get.return_value = good_response
-        get_typeform_responses()
-        self.assertTrue(mock_requests.get.called)
-        self.assertTrue(good_response.json.called)
+        # make sure that success is appropriately logged.
+        mock_requests.get.return_value = FakeTypeformAPIResponses.OK
+        with self.assertLogs( current_app.logger, level='INFO' ) as context_manager:
+            get_typeform_responses()
+            self.assertTrue(mock_requests.get.called)
+            self.assertTrue(FakeTypeformAPIResponses.OK.json.called)
+        self.assertIn('TYPEFORM_GET_RESPONSES', context_manager.output[0])
+        self.assertIn('2 responses', context_manager.output[0])
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_typeform_failures(self, mock_requests):
+        # make sure that any non-ok responses raise and log HTTP Errors
+        mock_requests.get.return_value = FakeTypeformAPIResponses.ERROR
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                get_typeform_responses()
+        mock_requests.get.return_value = FakeTypeformAPIResponses.NOT_FOUND
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                get_typeform_responses()
+        mock_requests.get.return_value = FakeTypeformAPIResponses.FORBIDDEN
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                get_typeform_responses()
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_seamless_submit_success(self, mock_requests):
+        mock_requests.post.return_value = FakeSeamlessDocsAPISubmitResponses.OK
+        with self.assertLogs( current_app.logger, level='INFO' ) as context_manager:
+            result = submit_answers_to_seamless_docs(self.doc_id, self.answers)
+        self.assertIn('SEAMLESS_POST_RESPONSE', context_manager.output[0])
+        self.assertIn("submitted to '{}'".format(self.doc_id), context_manager.output[0])
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_seamless_submit_http_errors(self, mock_requests):
+        # HTTP Errors
+        mock_requests.post.return_value = FakeSeamlessDocsAPISubmitResponses.ERROR
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                submit_answers_to_seamless_docs(self.doc_id, self.answers)
+        mock_requests.post.return_value = FakeSeamlessDocsAPISubmitResponses.NOT_FOUND
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                submit_answers_to_seamless_docs(self.doc_id, self.answers)
+        mock_requests.post.return_value = FakeSeamlessDocsAPISubmitResponses.FORBIDDEN
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                submit_answers_to_seamless_docs(self.doc_id, self.answers)
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_seamless_submit_misc_errors(self, mock_requests):
+        # incorrect form id
+        mock_requests.post.return_value = FakeSeamlessDocsAPISubmitResponses.MISSING_DOC
+        with self.assertRaises(SeamlessDocsSubmissionError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                submit_answers_to_seamless_docs(self.doc_id, self.answers)
+
+        # validation error
+        mock_requests.post.return_value = FakeSeamlessDocsAPISubmitResponses.VALIDATION_ERROR
+        with self.assertRaises(SeamlessDocsSubmissionError):
+            with self.assertLogs( current_app.logger, level='ERROR') as context_manager:
+                submit_answers_to_seamless_docs(self.doc_id, self.answers)
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_seamless_pdf_success(self, mock_requests):
+        mock_requests.get.return_value = FakeSeamlessDocsAPIApplicationResponses.OK
+        with self.assertLogs( current_app.logger, level='INFO' ) as context_manager:
+            result = retrieve_seamless_docs_pdf_url(self.app_id)
+        self.assertIn('SEAMLESS_PDF_RESPONSE', context_manager.output[0])
+        self.assertIn("pdf retrieved for '{}'".format(self.app_id), context_manager.output[0])
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_seamless_pdf_missing(self, mock_requests):
+        mock_requests.get.return_value = FakeSeamlessDocsAPIApplicationResponses.MISSING_PDF
+        with self.assertRaises(NotFound):
+            with self.assertLogs( current_app.logger, level='WARNING' ) as context_manager:
+                result = retrieve_seamless_docs_pdf_url(self.app_id)
+            self.assertIn("pdf not found for '{}'".format(self.app_id), context_manager.output[0])
+
+    @patch('typeseam.form_filler.tasks.requests')
+    def test_seamless_pdf_http_error(self, mock_requests):
+        mock_requests.get.return_value = FakeSeamlessDocsAPIApplicationResponses.ERROR
+        with self.assertRaises(HTTPError):
+            with self.assertLogs( current_app.logger, level='ERROR' ) as context_manager:
+                result = retrieve_seamless_docs_pdf_url(self.app_id)
+

--- a/tests/unit/test_save.py
+++ b/tests/unit/test_save.py
@@ -45,10 +45,12 @@ class TestModelSaving(BaseTestCase):
     @attr(speed="slow")
     def test_save_everything(self):
         data = generate_fake_data(num_users=10)
-        user_report, user_data, users, form_sets, response_sets = data
+        user_report, user_data, users, form_sets, doc_sets, response_sets = data
         users = User.query.all()
         forms = Typeform.query.all()
+        docs = SeamlessDoc.query.all()
         responses = TypeformResponse.query.all()
         self.assertTrue(len(users) == 10)
         self.assertTrue(len(forms) > 0)
+        self.assertTrue(len(docs) > 0)
         self.assertTrue(len(responses) > 0)

--- a/typeseam/form_filler/logs.py
+++ b/typeseam/form_filler/logs.py
@@ -1,0 +1,26 @@
+from flask import current_app
+
+LOG_LEVELS = {
+    'debug':    10,
+    'info':     20,
+    'warning':  30,
+    'error':    40,
+    'critical': 50,
+}
+
+class SimpleLogEvent:
+    def __init__(self, event_type="EVENT", level='info'):
+        self.level = level
+        self.level_code = LOG_LEVELS[level]
+        self.event_type = event_type
+
+    def __call__(self, msg, *args, **kwargs):
+        current_app.logger.log(
+            self.level_code,
+            self.event_type + " " + msg, *args, **kwargs)
+
+
+log_typeform_get = SimpleLogEvent("TYPEFORM_GET_RESPONSES")
+log_seamless_post = SimpleLogEvent("SEAMLESS_POST_RESPONSE")
+log_seamless_get_pdf = SimpleLogEvent("SEAMLESS_PDF_RESPONSE")
+log_seamless_pdf_missing = SimpleLogEvent("SEAMLESS_PDF_MISSING", 'warning')

--- a/typeseam/form_filler/models.py
+++ b/typeseam/form_filler/models.py
@@ -24,8 +24,7 @@ class SeamlessDoc(db.Model):
     id = db.Column(db.Integer, primary_key=True, index=True)
     seamless_key = db.Column(db.String(64))
     user_id = db.Column(db.Integer, db.ForeignKey('auth_user.id'))
-    typeform_id = db.Column(
-        db.Integer, db.ForeignKey('form_filler_typeform.id'))
+    added_on = db.Column(db.DateTime(), server_default=db.func.now())
 
     def __repr__(self):
         return '<SeamlessDoc:"{}">'.format(self.seamless_key)

--- a/typeseam/form_filler/tasks.py
+++ b/typeseam/form_filler/tasks.py
@@ -1,12 +1,19 @@
 import requests
 import os
 import time
-from pprint import pprint
-from flask import abort
+from flask import abort, current_app as app
 from typeseam.app import db
 from typeseam.utils import seamless_auth
-from typeseam.form_filler import queries, models
+from typeseam.form_filler import queries, models, logs
 
+
+SEAMLESS_BASE_URL = 'https://cleanslate.seamlessdocs.com/api/'
+
+class SeamlessDocsSubmissionError(Exception):
+    pass
+
+class SeamlessDocsPDFError(Exception):
+    pass
 
 def get_typeform_responses(form=None):
     if not form:
@@ -19,38 +26,63 @@ def get_typeform_responses(form=None):
     args = {
         'key': os.environ.get('TYPEFORM_API_KEY', None),
         'completed': 'true'}
-    data = requests.get(url, params=args).json()
-    queries.save_new_typeform_data(data, form)
+    response = requests.get(url, params=args)
+    response.raise_for_status()
+    data = response.json()
+    logs.log_typeform_get("'{id}', {count} responses".format(
+        id=form_key, count=data['stats']['responses']['showing']))
+    queries.save_new_typeform_data(response.json(), form)
 
 
-def get_seamless_doc_pdf(response_id):
+def get_seamless_doc_pdf(response_id, pdf_wait_time=10):
     response = queries.get_response_model(response_id)
-    base_url = 'https://cleanslate.seamlessdocs.com/api/'
     if not response.seamless_id:
         form_id = os.environ.get('DEFAULT_SEAMLESS_FORM_ID')
     else:
         form_id = queries.get_seamless_doc_key_for_response(response)
-    submit_url = base_url + 'form/{}/submit'.format(form_id)
-    submit_result = requests.post(
-        submit_url, auth=seamless_auth.build_seamless_auth(),
-        data=response.answers).json()
-    if 'application_id' in submit_result:
-        response.seamless_submission_id = submit_result['application_id']
-        db.session.commit()
-    else:
-        # these abort errors should be more specific
-        abort(404)
-    app_url = base_url + 'application/{}'.format(
-        response.seamless_submission_id)
-    # wait for the pdf to be generated
-    time.sleep(10)
-    app_result = requests.get(
-        app_url, auth=seamless_auth.build_seamless_auth()).json()
-    response.pdf_url = app_result.get('submission_pdf_url', '')
-    if response.pdf_url:
-        db.session.commit()
-    else:
-        abort(404)
+    submit_result = submit_answers_to_seamless_docs(form_id, response.answers)
+    response.seamless_submission_id = submit_result['application_id']
+    db.session.commit()
+    # wait
+    time.sleep(pdf_wait_time)
+    response.pdf_url = retrieve_seamless_docs_pdf_url(response.seamless_submission_id)
+    db.session.commit()
     form = queries.get_typeform(id=response.typeform_id)
     response_data = queries.response_serializer.dump(response).data
     return form, response_data
+
+
+def submit_answers_to_seamless_docs(form_id, answers):
+    submit_url = SEAMLESS_BASE_URL + 'form/{}/submit'.format(form_id)
+    response = requests.post(
+        submit_url, auth=seamless_auth.build_seamless_auth(),
+        data=answers)
+    response.raise_for_status()
+    data = response.json()
+    if 'application_id' not in data:
+        raise SeamlessDocsSubmissionError(
+            "{response_text}".format(response_text=response.text))
+    logs.log_seamless_post("'{app_id}' submitted to '{form_id}'".format(
+        form_id=form_id, app_id=data['application_id']))
+    return data
+
+
+def retrieve_seamless_docs_pdf_url(application_id):
+    app_url = SEAMLESS_BASE_URL + 'application/{app_id}/update_pdf'.format(
+        app_id=application_id)
+    response = requests.get(
+        app_url, auth=seamless_auth.build_seamless_auth())
+    response.raise_for_status()
+    data = response.json()
+    if data and isinstance(data, list) and '.pdf' in data[0]:
+        logs.log_seamless_get_pdf(
+            "pdf retrieved for '{app_id}'".format(app_id=application_id))
+        return data[0]
+    elif isinstance(data, list) and not data:
+        logs.log_seamless_pdf_missing(
+            "pdf not found for '{app_id}'".format(app_id=application_id))
+        abort(404)
+    else:
+        raise SeamlessDocsSubmissionError(
+            "{response_text}".format(response_text=response.text))
+

--- a/typeseam/setup_logging.py
+++ b/typeseam/setup_logging.py
@@ -1,28 +1,21 @@
 import sys
 import logging
 
-def register_logging(app, config_string):
-    if 'prod' in config_string.lower():
-
-        # for heroku, just send everything to the console (instead of a file)
-        # and it will forward automatically to the logging service
-
-        # disable the existing flask handler, we are replacing it with our own
-        app.logger.removeHandler(app.logger.handlers[0])
-
-        app.logger.setLevel(logging.DEBUG)
-        stdout = logging.StreamHandler(sys.stdout)
-        stdout.setFormatter(logging.Formatter('''
+DEFAULT_LOGGING_FORMAT = '''
 
 %(asctime)s
 %(levelname)s in %(module)s [%(funcName)s] | [%(pathname)s:%(lineno)d]
 %(message)s
 --------------------------------------------------------------------------------
-'''))
-        app.logger.addHandler(stdout)
+'''
 
+def register_logging(app, config_string):
+    app.logger.removeHandler(app.logger.handlers[0])
+    if 'prod' in config_string.lower():
+        app.logger.setLevel(logging.INFO)
     else:
-        # log to console for dev & testing
         app.logger.setLevel(logging.DEBUG)
-
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(DEFAULT_LOGGING_FORMAT))
+    app.logger.addHandler(stdout_handler)
     return None

--- a/typeseam/setup_logging.py
+++ b/typeseam/setup_logging.py
@@ -2,12 +2,7 @@ import sys
 import logging
 
 DEFAULT_LOGGING_FORMAT = '''
-
-%(asctime)s
-%(levelname)s in %(module)s [%(funcName)s] | [%(pathname)s:%(lineno)d]
-%(message)s
---------------------------------------------------------------------------------
-'''
+%(asctime)s %(levelname)s %(module)s.%(funcName)s[%(lineno)d] %(message)s'''
 
 def register_logging(app, config_string):
     app.logger.removeHandler(app.logger.handlers[0])

--- a/typeseam/setup_logging.py
+++ b/typeseam/setup_logging.py
@@ -2,7 +2,7 @@ import sys
 import logging
 
 DEFAULT_LOGGING_FORMAT = '''
-%(asctime)s %(levelname)s %(module)s.%(funcName)s[%(lineno)d] %(message)s'''
+%(asctime)s %(levelname)s %(message)s'''
 
 def register_logging(app, config_string):
     app.logger.removeHandler(app.logger.handlers[0])


### PR DESCRIPTION
In anticipation of doing our first test runs with users, I'd like to improve the test coverage of external API calls and do a better job of logging them. The external calls seem like the mostly likely place to encounter problems, and these fragile connections should be handled more carefully.

This addresses #4.