### PR TITLE
Add metadata to the HTML template header

### DIFF
--- a/typeseam/content_constants.py
+++ b/typeseam/content_constants.py
@@ -10,7 +10,7 @@ credibility_note = str("Clear My Record is a free, non-profit service from "
     "Code for America for people with a criminal record in San Francisco. "
     "We are not a law firm and the information on this site is not legal advice.")
 
-gov_service_name = "Clean Slate is the San Francisco Public Defender’s record clearance program"
+gov_service_name = "Clean Slate is the San Francisco Public Defender's record clearance program"
 gov_service_description = str(
     "Clearing your record means you might be able to access more "
     "employment, housing, education, and financial opportunities. Clear My Record is "

--- a/typeseam/content_constants.py
+++ b/typeseam/content_constants.py
@@ -58,5 +58,4 @@ footer_cleanslate = str(
 
 metadata_title = "Clear My Record | Get help clearing your criminal record in San Francisco"
 metadata_description = "Clear My Record is a free, non-profit service that can help you remove convictions from your criminal record."
-metadata_image_url = "https://clearmyrecord.codeforamerica.org/static/img/CMR-hero.png"
 metadata_author = "Clear My Record (by Code for America)"

--- a/typeseam/content_constants.py
+++ b/typeseam/content_constants.py
@@ -55,3 +55,8 @@ footer_legal = "Read our Privacy Policy"
 footer_cleanslate = str(
     "Learn more about "
     "Clean Slate")
+
+metadata_title = "Clear My Record | Get help clearing your criminal record in San Francisco"
+metadata_description = "Clear My Record is a free, non-profit service that can help you remove convictions from your criminal record."
+metadata_image_url = "https://clearmyrecord.codeforamerica.org/static/img/CMR-hero.png"
+metadata_author = "Clear My Record (by Code for America)"

--- a/typeseam/context_processors.py
+++ b/typeseam/context_processors.py
@@ -63,6 +63,5 @@ def add_content_constants():
     return dict(
         content=content_constants,
         linkify=Linkifier(linkify_links),
-        current_local_time=current_local_time,
-        current_page_url=request.url
+        current_local_time=current_local_time
         )

--- a/typeseam/context_processors.py
+++ b/typeseam/context_processors.py
@@ -64,4 +64,5 @@ def add_content_constants():
         content=content_constants,
         linkify=Linkifier(linkify_links),
         current_local_time=current_local_time,
+        current_page_url=request.url
         )

--- a/typeseam/templates/includes/head.html
+++ b/typeseam/templates/includes/head.html
@@ -2,6 +2,33 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="csrf-token" content="{{ csrf_token() }}">
+
+{# Description and basic stuff #}
+<meta name="description" content="{{ content.metadata_description }}">
+<meta name="author" content="{{ content.metadata_author }}">
+
+{# Schema.org markup for Google+ #}
+<meta itemprop="name" content="{{ content.metadata_title }}" />
+<meta itemprop="description" content="{{ content.metadata_description }}">
+<meta itemprop="image" content="{{ content.metadata_image_url }}">
+
+{# Twitter card data #}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@codeforamerica">
+<meta name="twitter:url" content="{{ content.current_page_url }}">
+<meta name="twitter:title" content="{{ content.metadata_title }}">
+<meta name="twitter:description" content="{{ content.metadata_description }}">
+<meta name="twitter:creator" content="@codeforamerica">
+<meta name="twitter:image:src" content="{{ content.metadata_image_url }}">
+
+{# Open Graph data #}
+<meta property="og:title" content="{{ content.metadata_title }}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="{{ current_page_url }}">
+<meta property="og:image" content="{{ content.metadata_image_url }}">
+<meta property="og:description" content="{{ content.metadata_description }}">
+<meta property="og:site_name" content="{{ content.metadata_author }}">
+
 <title>
 {%- if page_title -%}
 {{- page_title -}}

--- a/typeseam/templates/includes/head.html
+++ b/typeseam/templates/includes/head.html
@@ -10,22 +10,22 @@
 {# Schema.org markup for Google+ #}
 <meta itemprop="name" content="{{ content.metadata_title }}" />
 <meta itemprop="description" content="{{ content.metadata_description }}">
-<meta itemprop="image" content="{{ content.metadata_image_url }}">
+<meta itemprop="image" content="{{ static_url }}img/CMR-hero.png">
 
 {# Twitter card data #}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@codeforamerica">
-<meta name="twitter:url" content="{{ content.current_page_url }}">
+<meta name="twitter:url" content="{{ request.url }}">
 <meta name="twitter:title" content="{{ content.metadata_title }}">
 <meta name="twitter:description" content="{{ content.metadata_description }}">
 <meta name="twitter:creator" content="@codeforamerica">
-<meta name="twitter:image:src" content="{{ content.metadata_image_url }}">
+<meta name="twitter:image:src" content="{{ static_url }}img/CMR-hero.png">
 
 {# Open Graph data #}
 <meta property="og:title" content="{{ content.metadata_title }}">
 <meta property="og:type" content="article">
-<meta property="og:url" content="{{ current_page_url }}">
-<meta property="og:image" content="{{ content.metadata_image_url }}">
+<meta property="og:url" content="{{ request.url }}">
+<meta property="og:image" content="{{ static_url }}img/CMR-hero.png">
 <meta property="og:description" content="{{ content.metadata_description }}">
 <meta property="og:site_name" content="{{ content.metadata_author }}">
 
@@ -33,6 +33,6 @@
 {%- if page_title -%}
 {{- page_title -}}
 {%- else -%}
-Clean Slate SF Applications
+{{ content.metadata_title }}
 {%- endif -%}
 </title>


### PR DESCRIPTION
# What this PR does

- Adds metadata tags to the `head.html` partial. This metadata should raise the page's rank on Google and other search engines, and generally improve discoverability through other services (Facebook, Twitter, any social network or client that reads standard metadata).
- Adds constants for the page title, description, and a relevant image to the `content_constants.py` file
- Small weirdly-lumped in fix: removes a non-ASCII character that was causing my install process through `make db.init` to fail

@bengolder I wasn't able to get the python environment to work locally, so this is improvised from how I think Jinja/Flask works. Please run this to make sure the request is coming through nicely. Also, let's sit together soon and you can walk me through venv and the bootstrapping process for the app.

# BEFORE YOU MERGE

I had no idea how to get the current page URL in the frontend. A cursory glance at the Flask docs showed `request.url` might be the way, but I have no idea if that works (couldn't test this locally).

Please check c6a8bc4 before merging and fix my likely stupid error.